### PR TITLE
Implement execution filtering options

### DIFF
--- a/src/selogger/logging/Logging.java
+++ b/src/selogger/logging/Logging.java
@@ -52,8 +52,8 @@ public class Logging {
 	 * @param outputDir specifies a directory where files are created.
 	 * @return the created logger instance.
 	 */
-	public static IEventLogger initializeFrequencyLogger(File outputDir, Weaver weaver, String weaveStart, String weaveEnd) {
-		INSTANCE = new EventFrequencyLogger(outputDir, weaver, weaveStart, weaveEnd);
+	public static IEventLogger initializeFrequencyLogger(File outputDir, Weaver weaver) {
+		INSTANCE = new EventFrequencyLogger(outputDir, weaver);
 		return INSTANCE;
 	}
 	

--- a/src/selogger/logging/Logging.java
+++ b/src/selogger/logging/Logging.java
@@ -9,6 +9,7 @@ import selogger.logging.io.EventStreamLogger;
 import selogger.logging.io.LatestEventLogger;
 import selogger.logging.io.LatestEventTimeLogger;
 import selogger.logging.io.MemoryLogger;
+import selogger.weaver.Weaver;
 
 
 
@@ -51,8 +52,8 @@ public class Logging {
 	 * @param outputDir specifies a directory where files are created.
 	 * @return the created logger instance.
 	 */
-	public static IEventLogger initializeFrequencyLogger(File outputDir, String weaveStart, String weaveEnd) {
-		INSTANCE = new EventFrequencyLogger(outputDir, weaveStart, weaveEnd);
+	public static IEventLogger initializeFrequencyLogger(File outputDir, Weaver weaver, String weaveStart, String weaveEnd) {
+		INSTANCE = new EventFrequencyLogger(outputDir, weaver, weaveStart, weaveEnd);
 		return INSTANCE;
 	}
 	

--- a/src/selogger/logging/Logging.java
+++ b/src/selogger/logging/Logging.java
@@ -51,8 +51,8 @@ public class Logging {
 	 * @param outputDir specifies a directory where files are created.
 	 * @return the created logger instance.
 	 */
-	public static IEventLogger initializeFrequencyLogger(File outputDir) {
-		INSTANCE = new EventFrequencyLogger(outputDir);
+	public static IEventLogger initializeFrequencyLogger(File outputDir, String weaveStart, String weaveEnd) {
+		INSTANCE = new EventFrequencyLogger(outputDir, weaveStart, weaveEnd);
 		return INSTANCE;
 	}
 	

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -43,16 +43,6 @@ public class EventFrequencyLogger implements IEventLogger {
 	private boolean isRecord;
 
 	/**
-	 * A dataid which starts recording the instruction.
-	 */
-	public static int weaveStartDataId = 100;
-	
-	/**
-	 * A dataid which ends recording the instruction.
-	 */
-	public static int weaveEndDataId = 199;
-	
-	/**
 	 * Create the logger object.
 	 * @param outputDir specifies a directory where a resultant file is stored
 	 */
@@ -61,7 +51,8 @@ public class EventFrequencyLogger implements IEventLogger {
 		counters = new ArrayList<>();
 		fng = new FileNameGenerator(outputDir, LOG_PREFIX, LOG_SUFFIX);
 		this.weaver = weaver;
-		isRecord = weaver.getFilteringStartDataId() == -1; 
+		//TODO fix this assignment when incorrect weaveStart
+		isRecord = weaver.getWeaveStart().equals(""); 
 	}
 	
 	
@@ -225,8 +216,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public synchronized void close() {
-//		try (PrintWriter w = new PrintWriter(new FileWriter(new File(outputDir, FILENAME)))) {
-		try (PrintWriter w = new PrintWriter(new FileWriter(fng.getNextFile()))) {
+		File file = weaver.getIsFiltering() ? fng.getNextFile() : new File(outputDir, FILENAME);
+		try (PrintWriter w = new PrintWriter(new FileWriter(file))) {
 			for (int i=0; i<counters.size(); i++) {
 				AtomicInteger c = counters.get(i);
 				int count = c.get();
@@ -236,6 +227,7 @@ public class EventFrequencyLogger implements IEventLogger {
 				}
 			}
 		} catch (IOException e) {
+			
 		}
 	}
 	

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -55,9 +55,6 @@ public class EventFrequencyLogger implements IEventLogger {
 		isRecord = weaver.getWeaveStart().equals(""); 
 	}
 	
-	
-	
-	
 	/**
 	 * Count the event occurrence.
 	 * @param dataId specifies an event to be counted.
@@ -65,12 +62,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, boolean value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -80,12 +72,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, byte value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -95,12 +82,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, char value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -110,12 +92,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, double value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -125,12 +102,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, float value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -140,12 +112,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, int value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -155,12 +122,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, long value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -170,12 +132,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, Object value) {
-		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
-		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaver.getFilteringEndDataId()) {
-			isRecord = false;
-			this.close();
-		}
+		recordEvent(dataId);
 	}
 	
 	/**
@@ -185,6 +142,10 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, short value) {
+		recordEvent(dataId);
+	}
+	
+	private void recordEvent(int dataId) {
 		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaver.getFilteringEndDataId()) {

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -31,13 +31,38 @@ public class EventFrequencyLogger implements IEventLogger {
 	private File outputDir;
 	
 	/**
+	 * A flag indicates whether the current interval is the specifed interval by option.
+	 */
+	private boolean isRecord = false;
+
+	/**
+	 * A dataid which starts recording the instruction.
+	 */
+	private int weaveStartDataId = 100;
+	
+	/**
+	 * A dataid which ends recording the instruction.
+	 */
+	private int weaveEndDataId = 200;
+	
+	/**
 	 * Create the logger object.
 	 * @param outputDir specifies a directory where a resultant file is stored
 	 */
-	public EventFrequencyLogger(File outputDir) {
+	public EventFrequencyLogger(File outputDir, String weaveStart, String weaveEnd) {
 		this.outputDir = outputDir;
 		counters = new ArrayList<>();
 	}
+	
+	
+	/**
+	 * Create the logger object.
+	 * @param outputDir specifies a directory where a resultant file is stored
+	 */
+	public void setIsRecord(){
+		isRecord = true;
+	}
+	
 	
 	/**
 	 * Count the event occurrence.
@@ -46,7 +71,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, boolean value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -56,7 +82,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, byte value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -66,7 +93,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, char value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -76,7 +104,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, double value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -86,7 +115,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, float value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -96,7 +126,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, int value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -106,7 +137,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, long value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -116,7 +148,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, Object value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -126,7 +159,8 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, short value) {
-		countOccurrence(dataId);
+		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import selogger.logging.IEventLogger;
+import selogger.logging.util.FileNameGenerator;
 
 /**
  * This class is an implementation of IEventLogger that counts
@@ -18,8 +19,13 @@ public class EventFrequencyLogger implements IEventLogger {
 	/**
 	 * The name of a file created by this logger
 	 */
-	private static final String FILENAME = "eventfreq.txt";
+	private static final String FILENAME = "eventfreq";
 
+	public static final String LOG_PREFIX = "eventfreq-";
+	public static final String LOG_SUFFIX = ".txt";
+	
+	FileNameGenerator fng;
+	
 	/**
 	 * Array of counter objects.  dataId is used as an index for this array.
 	 */
@@ -52,6 +58,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	public EventFrequencyLogger(File outputDir, String weaveStart, String weaveEnd) {
 		this.outputDir = outputDir;
 		counters = new ArrayList<>();
+		fng = new FileNameGenerator(outputDir, LOG_PREFIX, LOG_SUFFIX);
 	}
 	
 	
@@ -71,7 +78,11 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, boolean value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 		if (isRecord) countOccurrence(dataId);
 	}
 	
@@ -82,8 +93,13 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, byte value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+//		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -93,8 +109,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, char value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -104,8 +124,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, double value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -115,8 +139,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, float value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -126,8 +154,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, int value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -137,8 +169,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, long value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -148,8 +184,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, Object value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -159,8 +199,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, short value) {
-		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaveEndDataId) {
+			isRecord = false;
+			this.close();
+		}
 	}
 	
 	/**
@@ -186,12 +230,14 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public synchronized void close() {
-		try (PrintWriter w = new PrintWriter(new FileWriter(new File(outputDir, FILENAME)))) {
+//		try (PrintWriter w = new PrintWriter(new FileWriter(new File(outputDir, FILENAME)))) {
+		try (PrintWriter w = new PrintWriter(new FileWriter(fng.getNextFile()))) {
 			for (int i=0; i<counters.size(); i++) {
 				AtomicInteger c = counters.get(i);
 				int count = c.get();
 				if (count > 0) {
 					w.println(i + "," + count);
+					c.set(0);
 				}
 			}
 		} catch (IOException e) {

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -20,7 +20,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	/**
 	 * The name of a file created by this logger
 	 */
-	private static final String FILENAME = "eventfreq";
+	private static final String FILENAME = "eventfreq.txt";
 
 	public static final String LOG_PREFIX = "eventfreq-";
 	public static final String LOG_SUFFIX = ".txt";

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import selogger.logging.IEventLogger;
 import selogger.logging.util.FileNameGenerator;
+import selogger.weaver.Weaver;
 
 /**
  * This class is an implementation of IEventLogger that counts
@@ -25,7 +26,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	public static final String LOG_SUFFIX = ".txt";
 	
 	FileNameGenerator fng;
-	
+	Weaver weaver;
+	String weaveStart;
+	String weaveEnd;
 	/**
 	 * Array of counter objects.  dataId is used as an index for this array.
 	 */
@@ -44,31 +47,39 @@ public class EventFrequencyLogger implements IEventLogger {
 	/**
 	 * A dataid which starts recording the instruction.
 	 */
-	private int weaveStartDataId = 100;
+	public static int weaveStartDataId = 100;
 	
 	/**
 	 * A dataid which ends recording the instruction.
 	 */
-	private int weaveEndDataId = 200;
+	public static int weaveEndDataId = 199;
 	
 	/**
 	 * Create the logger object.
 	 * @param outputDir specifies a directory where a resultant file is stored
 	 */
-	public EventFrequencyLogger(File outputDir, String weaveStart, String weaveEnd) {
+	public EventFrequencyLogger(File outputDir, Weaver weaver, String weaveStart, String weaveEnd) {
 		this.outputDir = outputDir;
 		counters = new ArrayList<>();
 		fng = new FileNameGenerator(outputDir, LOG_PREFIX, LOG_SUFFIX);
+		this.weaver = weaver;
+		this.weaveStart = weaveStart;
+		this.weaveEnd = weaveEnd;
 	}
 	
 	
-	/**
-	 * Create the logger object.
-	 * @param outputDir specifies a directory where a resultant file is stored
-	 */
+	
 	public void setIsRecord(){
-		isRecord = true;
+//		isRecord = true;
 	}
+	
+	public void setDataId(){
+//		isRecord = true;
+		//weaverのweaveLogからmethodname-methodID pair取ってきてmethodname to methodIDに変換する
+		// dataidのなかでmethodIDが該当するものを取ってweaveStart/EndDataIdに代入
+		//weaver;
+	}
+	
 	
 	
 	/**
@@ -78,6 +89,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, boolean value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if(dataId == weaveEndDataId) {
 			isRecord = false;
@@ -94,6 +108,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	@Override
 	public void recordEvent(int dataId, byte value) {
 //		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -109,6 +126,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, char value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -124,6 +144,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, double value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -139,6 +162,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, float value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -154,6 +180,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, int value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -169,6 +198,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, long value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -184,6 +216,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, Object value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {
@@ -199,6 +234,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, short value) {
+		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
+			setDataId();
+		}
 		if(dataId == weaveStartDataId)  isRecord =true; 
 		if (isRecord) countOccurrence(dataId);
 		if(dataId == weaveEndDataId) {

--- a/src/selogger/logging/io/EventFrequencyLogger.java
+++ b/src/selogger/logging/io/EventFrequencyLogger.java
@@ -27,8 +27,6 @@ public class EventFrequencyLogger implements IEventLogger {
 	
 	FileNameGenerator fng;
 	Weaver weaver;
-	String weaveStart;
-	String weaveEnd;
 	/**
 	 * Array of counter objects.  dataId is used as an index for this array.
 	 */
@@ -42,7 +40,7 @@ public class EventFrequencyLogger implements IEventLogger {
 	/**
 	 * A flag indicates whether the current interval is the specifed interval by option.
 	 */
-	private boolean isRecord = false;
+	private boolean isRecord;
 
 	/**
 	 * A dataid which starts recording the instruction.
@@ -58,27 +56,14 @@ public class EventFrequencyLogger implements IEventLogger {
 	 * Create the logger object.
 	 * @param outputDir specifies a directory where a resultant file is stored
 	 */
-	public EventFrequencyLogger(File outputDir, Weaver weaver, String weaveStart, String weaveEnd) {
+	public EventFrequencyLogger(File outputDir, Weaver weaver) {
 		this.outputDir = outputDir;
 		counters = new ArrayList<>();
 		fng = new FileNameGenerator(outputDir, LOG_PREFIX, LOG_SUFFIX);
 		this.weaver = weaver;
-		this.weaveStart = weaveStart;
-		this.weaveEnd = weaveEnd;
+		isRecord = weaver.getFilteringStartDataId() == -1; 
 	}
 	
-	
-	
-	public void setIsRecord(){
-//		isRecord = true;
-	}
-	
-	public void setDataId(){
-//		isRecord = true;
-		//weaverのweaveLogからmethodname-methodID pair取ってきてmethodname to methodIDに変換する
-		// dataidのなかでmethodIDが該当するものを取ってweaveStart/EndDataIdに代入
-		//weaver;
-	}
 	
 	
 	
@@ -89,15 +74,12 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, boolean value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
+		if (isRecord) countOccurrence(dataId);
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
-		if (isRecord) countOccurrence(dataId);
 	}
 	
 	/**
@@ -107,13 +89,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, byte value) {
-//		isRecord = (dataId == weaveStartDataId || isRecord) && dataId != weaveEndDataId;
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -126,12 +104,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, char value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -144,12 +119,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, double value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -162,12 +134,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, float value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -180,12 +149,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, int value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -198,12 +164,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, long value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -216,12 +179,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, Object value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}
@@ -234,12 +194,9 @@ public class EventFrequencyLogger implements IEventLogger {
 	 */
 	@Override
 	public void recordEvent(int dataId, short value) {
-		if (weaveStartDataId == -1 || weaveEndDataId ==-1){
-			setDataId();
-		}
-		if(dataId == weaveStartDataId)  isRecord =true; 
+		if(dataId == weaver.getFilteringStartDataId())  isRecord =true; 	
 		if (isRecord) countOccurrence(dataId);
-		if(dataId == weaveEndDataId) {
+		if(dataId == weaver.getFilteringEndDataId()) {
 			isRecord = false;
 			this.close();
 		}

--- a/src/selogger/weaver/RuntimeWeaver.java
+++ b/src/selogger/weaver/RuntimeWeaver.java
@@ -8,8 +8,8 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 
-import selogger.logging.Logging;
 import selogger.logging.IEventLogger;
+import selogger.logging.Logging;
 
 /**
  * This class is the main program of SELogger as a javaagent.
@@ -69,6 +69,8 @@ public class RuntimeWeaver implements ClassFileTransformer {
 		String dirname = SELOGGER_DEFAULT_OUTPUT_DIR;
 		String weaveOption = WeaveConfig.KEY_RECORD_ALL;
 		String classDumpOption = "false";
+		String weaveStart = "";
+		String weaveEnd = "";
 		exclusion = new ArrayList<String>();
 		for (String pkg: SYSTEM_PACKAGES) exclusion.add(pkg);
 
@@ -104,37 +106,35 @@ public class RuntimeWeaver implements ClassFileTransformer {
 				} else if (opt.startsWith("latest-simple")||opt.startsWith("fixed")) {
 					mode = Mode.FixedSize;
 				}
+			} else if (arg.startsWith("weaveStart=")) {
+				weaveStart = arg.substring("weaveStart=".length());
+			} else if (arg.startsWith("weaveEnd=")) {
+				weaveEnd = arg.substring("weaveEnd=".length());
 			}
 		}
-		
 		File outputDir = new File(dirname);
 		if (!outputDir.exists()) {
 			outputDir.mkdirs();
 		}
-		
+
 		if (outputDir.isDirectory() && outputDir.canWrite()) {
 			WeaveConfig config = new WeaveConfig(weaveOption);
 			if (config.isValid()) {
 				weaver = new Weaver(outputDir, config);
 				weaver.setDumpEnabled(classDumpOption.equalsIgnoreCase("true"));
-				
 				switch (mode) {
 				case FixedSize:
 					logger = Logging.initializeLatestDataLogger(outputDir, bufferSize, keepObject);
 					break;
-					
 				case FixedSizeTimestamp:
 					logger = Logging.initializeLatestEventTimeLogger(outputDir, bufferSize, keepObject);
 					break;
-				
 				case Frequency:
-					logger = Logging.initializeFrequencyLogger(outputDir);
+					logger = Logging.initializeFrequencyLogger(outputDir, weaveStart, weaveEnd);
 					break;
-					
 				case Stream:
 					logger = Logging.initializeStreamLogger(outputDir, true, weaver);
 					break;
-					
 				case Discard:
 					logger = Logging.initializeDiscardLogger();
 					break;
@@ -148,7 +148,6 @@ public class RuntimeWeaver implements ClassFileTransformer {
 			weaver = null;
 		}
 	}
-	
 	/**
 	 * @return true if the logging is executable
 	 */
@@ -163,7 +162,6 @@ public class RuntimeWeaver implements ClassFileTransformer {
 		logger.close();
 		weaver.close();
 	}
-	
 	/**
 	 * This method checks whether a given class is a logging target or not. 
 	 * @param className specifies a class.  A package separator is "/".
@@ -186,9 +184,9 @@ public class RuntimeWeaver implements ClassFileTransformer {
 	@Override
 	public synchronized byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
 			ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
-		
+
 		if (isExcludedFromLogging(className)) return null;
-		
+
 		if (protectionDomain != null) {
 			CodeSource s = protectionDomain.getCodeSource();
 			String l;

--- a/src/selogger/weaver/RuntimeWeaver.java
+++ b/src/selogger/weaver/RuntimeWeaver.java
@@ -56,6 +56,9 @@ public class RuntimeWeaver implements ClassFileTransformer {
 	private static final String[] SYSTEM_PACKAGES =  { "sun/", "com/sun/", "java/", "javax/" };
 	private static final String ARG_SEPARATOR = ",";
 	private static final String SELOGGER_DEFAULT_OUTPUT_DIR = "selogger-output";
+	
+	public static String WEAVESTART;
+	public static String WEAVEEND;
 
 	public enum Mode { Stream, Frequency, FixedSize, FixedSizeTimestamp, Discard };
 
@@ -108,8 +111,10 @@ public class RuntimeWeaver implements ClassFileTransformer {
 				}
 			} else if (arg.startsWith("weaveStart=")) {
 				weaveStart = arg.substring("weaveStart=".length());
+				WEAVESTART=weaveStart;
 			} else if (arg.startsWith("weaveEnd=")) {
 				weaveEnd = arg.substring("weaveEnd=".length());
+				WEAVEEND=weaveEnd;
 			}
 		}
 		File outputDir = new File(dirname);
@@ -130,7 +135,7 @@ public class RuntimeWeaver implements ClassFileTransformer {
 					logger = Logging.initializeLatestEventTimeLogger(outputDir, bufferSize, keepObject);
 					break;
 				case Frequency:
-					logger = Logging.initializeFrequencyLogger(outputDir, weaveStart, weaveEnd);
+					logger = Logging.initializeFrequencyLogger(outputDir, weaver, weaveStart, weaveEnd);
 					break;
 				case Stream:
 					logger = Logging.initializeStreamLogger(outputDir, true, weaver);

--- a/src/selogger/weaver/RuntimeWeaver.java
+++ b/src/selogger/weaver/RuntimeWeaver.java
@@ -56,9 +56,6 @@ public class RuntimeWeaver implements ClassFileTransformer {
 	private static final String[] SYSTEM_PACKAGES =  { "sun/", "com/sun/", "java/", "javax/" };
 	private static final String ARG_SEPARATOR = ",";
 	private static final String SELOGGER_DEFAULT_OUTPUT_DIR = "selogger-output";
-	
-	public static String WEAVESTART;
-	public static String WEAVEEND;
 
 	public enum Mode { Stream, Frequency, FixedSize, FixedSizeTimestamp, Discard };
 
@@ -111,10 +108,8 @@ public class RuntimeWeaver implements ClassFileTransformer {
 				}
 			} else if (arg.startsWith("weaveStart=")) {
 				weaveStart = arg.substring("weaveStart=".length());
-				WEAVESTART=weaveStart;
 			} else if (arg.startsWith("weaveEnd=")) {
 				weaveEnd = arg.substring("weaveEnd=".length());
-				WEAVEEND=weaveEnd;
 			}
 		}
 		File outputDir = new File(dirname);
@@ -125,24 +120,24 @@ public class RuntimeWeaver implements ClassFileTransformer {
 		if (outputDir.isDirectory() && outputDir.canWrite()) {
 			WeaveConfig config = new WeaveConfig(weaveOption);
 			if (config.isValid()) {
-				weaver = new Weaver(outputDir, config);
+				weaver = new Weaver(outputDir, weaveStart, weaveEnd, config);
 				weaver.setDumpEnabled(classDumpOption.equalsIgnoreCase("true"));
 				switch (mode) {
-				case FixedSize:
-					logger = Logging.initializeLatestDataLogger(outputDir, bufferSize, keepObject);
-					break;
-				case FixedSizeTimestamp:
-					logger = Logging.initializeLatestEventTimeLogger(outputDir, bufferSize, keepObject);
-					break;
-				case Frequency:
-					logger = Logging.initializeFrequencyLogger(outputDir, weaver, weaveStart, weaveEnd);
-					break;
-				case Stream:
-					logger = Logging.initializeStreamLogger(outputDir, true, weaver);
-					break;
-				case Discard:
-					logger = Logging.initializeDiscardLogger();
-					break;
+					case FixedSize:
+						logger = Logging.initializeLatestDataLogger(outputDir, bufferSize, keepObject);
+						break;
+					case FixedSizeTimestamp:
+						logger = Logging.initializeLatestEventTimeLogger(outputDir, bufferSize, keepObject);
+						break;
+					case Frequency:
+						logger = Logging.initializeFrequencyLogger(outputDir, weaver);
+						break;
+					case Stream:
+						logger = Logging.initializeStreamLogger(outputDir, true, weaver);
+						break;
+					case Discard:
+						logger = Logging.initializeDiscardLogger();
+						break;
 				}
 			} else {
 				System.out.println("No weaving option is specified.");

--- a/src/selogger/weaver/RuntimeWeaver.java
+++ b/src/selogger/weaver/RuntimeWeaver.java
@@ -112,6 +112,7 @@ public class RuntimeWeaver implements ClassFileTransformer {
 				weaveEnd = arg.substring("weaveEnd=".length());
 			}
 		}
+		
 		File outputDir = new File(dirname);
 		if (!outputDir.exists()) {
 			outputDir.mkdirs();
@@ -126,15 +127,19 @@ public class RuntimeWeaver implements ClassFileTransformer {
 					case FixedSize:
 						logger = Logging.initializeLatestDataLogger(outputDir, bufferSize, keepObject);
 						break;
+						
 					case FixedSizeTimestamp:
 						logger = Logging.initializeLatestEventTimeLogger(outputDir, bufferSize, keepObject);
 						break;
+						
 					case Frequency:
 						logger = Logging.initializeFrequencyLogger(outputDir, weaver);
 						break;
+						
 					case Stream:
 						logger = Logging.initializeStreamLogger(outputDir, true, weaver);
 						break;
+						
 					case Discard:
 						logger = Logging.initializeDiscardLogger();
 						break;

--- a/src/selogger/weaver/Weaver.java
+++ b/src/selogger/weaver/Weaver.java
@@ -65,11 +65,13 @@ public class Weaver implements IErrorLogger {
 	public Weaver(File outputDir, String weaveStart, String weaveEnd, WeaveConfig config) {	
 		assert outputDir.isDirectory() && outputDir.canWrite();
 		
+		isFiltering = !(weaveStart.equals("") && weaveEnd.equals(""));
 		this.weaveStart = weaveStart;
 		this.weaveEnd = weaveEnd;
-		isFiltering = !(weaveStart.equals("") && weaveEnd.equals(""));
 		startMethodId = -1;
 		endMethodId = -1;
+		filteringStartDataId = -1;
+		filteringEndDataId = -1;
 
 		this.outputDir = outputDir;
 		this.config = config;
@@ -273,7 +275,7 @@ public class Weaver implements IErrorLogger {
 							if(loc.getMethodId() == startMethodId) {
 								filteringStartDataId = loc.getDataId() + 1;
 								startMethodId = -1;
-//								System.out.println("start:" + filteringStartDataId);
+								System.out.println("start:" + filteringStartDataId);
 							}
 						}
 						if(endMethodId != -1) {
@@ -284,7 +286,7 @@ public class Weaver implements IErrorLogger {
 									//TODO 再帰どうするか検討する
 									filteringEndDataId = loc.getDataId();
 									endMethodId = -1;
-//									System.out.println("end:" + filteringEndDataId);
+									System.out.println("end:" + filteringEndDataId);
 								}
 							}
 						}
@@ -342,6 +344,10 @@ public class Weaver implements IErrorLogger {
 	
 	public boolean getIsFiltering() {
 		return isFiltering;
+	}
+
+	public String getWeaveStart() {
+		return weaveStart;
 	}
 
 	public int getFilteringStartDataId() {

--- a/src/selogger/weaver/Weaver.java
+++ b/src/selogger/weaver/Weaver.java
@@ -275,18 +275,16 @@ public class Weaver implements IErrorLogger {
 							if(loc.getMethodId() == startMethodId) {
 								filteringStartDataId = loc.getDataId() + 1;
 								startMethodId = -1;
-								System.out.println("start:" + filteringStartDataId);
 							}
 						}
 						if(endMethodId != -1) {
 							if(loc.getMethodId() == endMethodId) {
 								//	if(loc.getEventType().toString().equals("METHOD_NORMAL_EXIT") || loc.getEventType().toString().equals("METHOD_EXCEPTIONAL_EXIT")) {
 								if(loc.getEventType().toString().equals("METHOD_NORMAL_EXIT")) {
-									//TODO どちらでも終了をひっかけられるようにする
-									//TODO 再帰どうするか検討する
+									//TODO set multiple endID because method can hook both exit event
+									//TODO limitation: recursive method call
 									filteringEndDataId = loc.getDataId();
 									endMethodId = -1;
-									System.out.println("end:" + filteringEndDataId);
 								}
 							}
 						}


### PR DESCRIPTION
## Implement filtering 
### Detail Implementation 
- add two options (weaveStart and weaveEnd)
  - In the option, you can specify the method name as the filtering start/end point.
  - Option format is the following.   `weaveStart=packageName/ClassName.Methodname, ...` 
- These option can filter the execution from **METHOD_ENTRY** event (specified by _weaveStart_ option) to **METHOD_NORMAL_EXIT** event (specified by _weaveEnd_ option) in the current implementation.
### Limitation

- The implementation is only for _freq_ mode now.
- The recursive method can not be recorded correctly in the current implementation.